### PR TITLE
Make CalculateTextWidth take const char* instead of just char*

### DIFF
--- a/infernity_common_v01.patch
+++ b/infernity_common_v01.patch
@@ -19,7 +19,7 @@ index 4e8c73be..67969eb4 100644
 +	}
 +}
 +
-+int CalculateTextWidth(char* s)
++int CalculateTextWidth(const char* s)
 +{
 +	int l = 0;
 +	while (*s) {
@@ -40,7 +40,7 @@ index 9648e5fd..badd498c 100644
  void CelDecDatLightOnly(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth, BYTE *tbl = NULL);
  void CelDecDatLightTrans(BYTE *pDecodeTo, BYTE *pRLEBytes, int nDataSize, int nWidth);
 +void DrawSolidRectangle(int x0, int dx, int y0, int dy, int color);
-+int CalculateTextWidth(char* s);
++int CalculateTextWidth(const char* s);
  void CelDecodeLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth);
  void CelDecodeHdrLightOnly(int sx, int sy, BYTE *pCelBuff, int nCel, int nWidth, int CelSkip, int CelCap);
  void CelDecodeHdrLightTrans(BYTE *pBuff, BYTE *pCelBuff, int nCel, int nWidth, int CelSkip, int CelCap);


### PR DESCRIPTION
It doesn't modify the contents of the string at any point so it's safe
to declare it as taking a pointer to const char. This allows building
DevilutionX with the patch applied, otherwise a compiler may prevent
compilation from happening because there are some pointers to const char
passed to the function, for example (in the monster bar patch):

    static const char* resText = "RES: ";
    (...)
    int resOffset = 0 + CalculateTextWidth(resText);